### PR TITLE
feat: add signal effect demo to react on count changes with alerts at 5 and 10

### DIFF
--- a/src/app/signals/signals.html
+++ b/src/app/signals/signals.html
@@ -23,5 +23,10 @@
   <p>X: {{x()}} + Y: {{y()}}</p>
   <p>Sum: {{sum()}}</p>
   <button (click)="changeComputedValue()">Change Computed Values</button>
-  <p>Note: we cannot change Values of the Computed Properties directly, but we can change the dependent Signals that they rely on.  </p>
+  <p>Note: we cannot change Values of the Computed Properties directly, but we can change the dependent Signals that they rely on.</p>
+
+  <hr>
+  <h3>Effects</h3>
+  <p>{{count()}}</p>
+  <button (click)="toggleEffect()">TOGGLE</button>
 </div>

--- a/src/app/signals/signals.ts
+++ b/src/app/signals/signals.ts
@@ -9,14 +9,9 @@ import { sign } from 'node:crypto';
 })
 export class Signals {
   value: WritableSignal<number | string> = signal(0);
-  count = signal<number>(0);
   number: WritableSignal<number> = signal(0);
 
-  constructor() {
-    effect(() => {
-      console.log('Number changed:', this.number());
-    });
-  }
+  
 
   clickHandle(condition: string) {
     if (condition === 'increase') {
@@ -51,5 +46,20 @@ export class Signals {
     this.x.set(this.x() + 10);
   }
 
+  // Effect
+  count = signal<number>(0);
+  constructor() {
+    effect(() => {
+      console.log('Count changed:', this.count());
+      if(this.count() == 5){
+        alert('Count reached 5!');
+      }else if(this.count() == 10){
+        alert('Count reached 10!');
+      }
+    });
+  }
+  toggleEffect(){
+    this.count.set(this.count() + 1);
+  }
 
 }


### PR DESCRIPTION
- Implemented an `effect` in the constructor that listens to changes in `count`.
- Effect logs the updated count and shows alerts when count reaches 5 and 10.
- Added `toggleEffect()` method to increment the count on button click.
- Updated template with a button and display for the current count.
